### PR TITLE
Fix typo in the repo name.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ author_email = admin@climateengine.com
 description = Python library for interacting with the SpatiaFi API
 long_description = file: README.md
 long_description_content_type = text/markdown
-url = https://github.com/climateengine/py-spfi-api
+url = https://github.com/climateengine/py-spatiafi
 
 [options]
 package_dir =


### PR DESCRIPTION
The setup.cfg was referring to a repo that did not exist. This would have taken users to a 404 page if they found our package on PyPi.

This commit corrects the typo.