### PR TITLE
TECH-661. Add a concurrency limit on the async session

### DIFF
--- a/src/spatiafi/async_queue.py
+++ b/src/spatiafi/async_queue.py
@@ -22,7 +22,7 @@ def worker(queue, task_function, print_progress=100, start_time=None):
     asyncio.set_event_loop(loop)
 
     # Create client
-    session = loop.run_until_complete(get_async_session())
+    session = loop.run_until_complete(get_async_session(max_connections_limit=200))
 
     # Create results store
     results = {}

--- a/src/spatiafi/session.py
+++ b/src/spatiafi/session.py
@@ -52,7 +52,7 @@ def get_session(app_credentials=None):
     return session
 
 
-async def get_async_session(app_credentials=None):
+async def get_async_session(app_credentials=None, max_connections_limit=None):
     """
     Get an automatically-refreshing async OAuth2 session for the SpatiaFI API.
 
@@ -78,7 +78,7 @@ async def get_async_session(app_credentials=None):
         token_endpoint_auth_method=ClientSecretJWT(
             "https://auth.spatiafi.com/api/v1/auth/jwt/token"
         ),
-        limits=httpx.Limits(max_connections=None),
+        limits=httpx.Limits(max_connections=max_connections_limit),
         timeout=httpx.Timeout(5.0, connect=1.0),
     )
     await session.fetch_token()

--- a/tests/test_async_queue.py
+++ b/tests/test_async_queue.py
@@ -33,7 +33,7 @@ async def get_point(item_id, row, session=None):
     Note: This is *not* a valid task function for AsyncQueue, because it takes two arguments.
     """
     if session is None:
-        session = await get_async_session()
+        session = await get_async_session(max_connections_limit=200)
 
     # Create the url.  Note that this assumes that the series/dict has indices "lat" and "lon".
     url = (


### PR DESCRIPTION
We were previously allowing the session to have an unbounded number of requests in flight at given time. This was causing issues for us.

This commit adds a new parameter `max_connections_limit` to the `get_async_session` function. This parameter if passed will limit the connection pool size of the underlying httpx session. See: https://www.python-httpx.org/advanced/#pool-limit-configuration

The number of connections 200 was selected arbitrarily.