### PR TITLE
TECH-661. Limit the number of background tasks at a given time.

### DIFF
--- a/src/spatiafi/async_queue.py
+++ b/src/spatiafi/async_queue.py
@@ -81,6 +81,10 @@ def worker(queue, task_function, print_progress=100, start_time=None):
             if err is not None:
                 break
 
+            # Wait for the number of background tasks to be less than 1000 before continuing to add new tasks.
+            while len(background_tasks) > 1000:
+                await asyncio.sleep(0.1)
+
             # get a work_item from the queue
             # work_item is a tuple of (task_number, task) so that we can return the results in order
             work_item = queue.get()


### PR DESCRIPTION
We experienced issues with this script with too many requests in flight. Instead of having everything in the queue and waiting, we here limit the number in flight by inspecting the `background_tasks` set. The task will sleep if there is more than a limit and then once the background tasks queue decreases we continue to get work off of the queue.