### PR TITLE
TECH-735 Add a test for `get_session`

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,4 +5,6 @@ set -eux -o pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 1
 
 pytest \
+    -W 'ignore::DeprecationWarning:pkg_resources:' \
+    -W 'ignore::DeprecationWarning:google.rpc:' \
     $@

--- a/tests/test_get_session.py
+++ b/tests/test_get_session.py
@@ -1,0 +1,17 @@
+from spatiafi.session import get_session
+
+
+def test_get_sync_session():
+    session = get_session()
+
+    # https://api.spatiafi.com/api/timeseries/point/-4.8759617382590985,59.015777063423926?coll_id=spatiafi-sea-level-rise-projections-global-v1.0-intlow
+
+    lon, lat = -4.8759617382590985, 59.015777063423926
+    coll_id = "spatiafi-sea-level-rise-projections-global-v1.0-intlow"
+    url = "https://api.spatiafi.com/api/timeseries/point/" + str(lon) + "," + str(lat)
+
+    query = {"coll_id": coll_id}
+
+    r = session.get(url, params=query)
+
+    assert r.status_code == 200


### PR DESCRIPTION
We were failing to fetch an access token which fails when we go to get
the first request and not when we construct the session.

We added a test for what was causing us issues in windows.