### PR TITLE
TECH-804. Allow clients to use proxies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,27 @@ url = "https://api.spatiafi.com/api/info"
 response = session.get(url, params=params)
 ```
 
+### Using a proxy
+
+If you're using the client in a constrained environment you may need to pass in
+`proxies` to the `get_session` function:
+
+```python
+from spatiafi import get_session
+
+proxies = {
+    "http": "http://fake-proxy.example.com:443",
+    "https": "http://fake-proxy.example.com:443",
+}
+
+session = get_session(proxies=proxies)
+
+params = {"item_id": "wildfire-risk-current-global-v1.0"}
+url = "https://api.spatiafi.com/api/info"
+
+response = session.get(url, params=params)
+```
+
 
 ### Get help with `gdal_auth`
 ```shell

--- a/src/spatiafi/session.py
+++ b/src/spatiafi/session.py
@@ -8,7 +8,7 @@ from urllib3.util import Retry
 from spatiafi import authenticate
 
 
-def get_session(app_credentials=None):
+def get_session(app_credentials=None, proxies=None):
     """
     Get an automatically-refreshing OAuth2 session (requests, sync) for the SpatiaFI API.
 
@@ -46,6 +46,10 @@ def get_session(app_credentials=None):
     )
     session.mount("http://", adapter)
     session.mount("https://", adapter)
+
+    if proxies:
+        session.proxies = proxies
+
     session.fetch_token()
     return session
 

--- a/tests/test_get_session.py
+++ b/tests/test_get_session.py
@@ -1,3 +1,5 @@
+import pytest
+import requests
 from spatiafi.session import get_session
 
 
@@ -15,3 +17,16 @@ def test_get_sync_session():
     r = session.get(url, params=query)
 
     assert r.status_code == 200
+
+
+def test_get_sync_session__with_proxy():
+    proxies = {
+        "http": "http://fake-proxy.example.com:443",
+        "https": "http://fake-proxy.example.com:443",
+    }
+
+    with pytest.raises(
+        requests.exceptions.ProxyError,
+        match="Failed to resolve 'fake-proxy.example.com'",
+    ):
+        get_session(proxies=proxies)


### PR DESCRIPTION
We have a client who would like to use the API in the context where they need to use a proxy in order to access the public internet.

In order to accommodate this in this commit we're adding a `proxies` argument to the `get_session` method.