### PR TITLE
Make the fake proxies more realistic

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ If you're using the client in a constrained environment you may need to pass in
 from spatiafi import get_session
 
 proxies = {
-    "http": "http://fake-proxy.example.com:443",
-    "https": "http://fake-proxy.example.com:443",
+    "http": "http://fake-proxy.example.com:8080",
+    "https": "https://fake-proxy.example.com:443",
 }
 
 session = get_session(proxies=proxies)


### PR DESCRIPTION
When we added this example recently we added it with the same string for both the http and https proxies. It's more likely that the https proxy will have an `https` prefix, and that the port will be a conventional port for the protocol (as in "443" is a more common https protocol and "8080" is a more common "http" protocol).